### PR TITLE
Don’t find node_modules up the directory tree when installing

### DIFF
--- a/commands/install.ts
+++ b/commands/install.ts
@@ -13,7 +13,6 @@ import {
   dim,
   elmToolingJsonDocumentationLink,
   Env,
-  findClosest,
   flatMap,
   indent,
   printNumErrors,
@@ -122,22 +121,12 @@ async function installTools(
   elmToolingJsonPath: string,
   tools: Tools
 ): Promise<number> {
-  const nodeModulesPath = findClosest(
+  const nodeModulesBinPath = path.join(
+    path.dirname(elmToolingJsonPath),
     "node_modules",
-    path.dirname(elmToolingJsonPath)
+    ".bin"
   );
-  if (nodeModulesPath === undefined) {
-    logger.error(bold(elmToolingJsonPath));
-    logger.error(
-      `No node_modules/ folder found upwards from: ${path.dirname(
-        elmToolingJsonPath
-      )}`
-    );
-    logger.error("Install your npm dependencies before running this script.");
-    return 1;
-  }
 
-  const nodeModulesBinPath = path.join(nodeModulesPath, ".bin");
   try {
     fs.mkdirSync(nodeModulesBinPath, { recursive: true });
   } catch (errorAny) {
@@ -261,16 +250,11 @@ function removeAllTools(
   logger.log(bold(elmToolingJsonPath));
   const message = `The "tools" field is ${what}. To add tools: elm-tooling tools`;
 
-  const nodeModulesPath = findClosest(
+  const nodeModulesBinPath = path.join(
+    path.dirname(elmToolingJsonPath),
     "node_modules",
-    path.dirname(elmToolingJsonPath)
+    ".bin"
   );
-  if (nodeModulesPath === undefined) {
-    logger.log(message);
-    return 0;
-  }
-
-  const nodeModulesBinPath = path.join(nodeModulesPath, ".bin");
 
   const results = removeTools(
     cwd,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,7 @@ _Note:_ You need to update `elm-tooling` itself to get new tool versions! See [W
 `elm-tooling install` does two things:
 
 1. Makes sure the [tools](./spec#tools) in the closest `elm-tooling.json` are available on disk. Downloads them if missing.
-2. Creates links in your local `node_modules/.bin/` folder to the downloaded tools, just like the `elm`, `elm-format`, etc, npm packages do. This allows you to run things like `npx elm make src/Main.elm`, and your editor and build tools will automatically find them.
+2. Creates links in your local `./node_modules/.bin/` folder to the downloaded tools, just like the `elm`, `elm-format`, etc, npm packages do. This allows you to run things like `npx elm make src/Main.elm`, and your editor and build tools will automatically find them. (The `node_modules/` folder is always located next to your `elm-tooling.json`.)
 
 In other words, `elm-tooling install` is a drop-in replacement for installing for example `elm` and `elm-format` with `npm`.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -206,7 +206,7 @@ The algorithm is roughly:
 
       4. Make sure the extracted file is executable (`chmod +x`).
 
-   3. Create a link in `./node_modules/.bin/`.
+   3. Create a link in `./node_modules/.bin/`. (The `node_modules/` folder is always located next to your `elm-tooling.json`.)
 
 ## Who uses `elm-tooling`?
 


### PR DESCRIPTION
`elm-tooling install` creates links in `node_modules/.bin/`.

Currently, it looks up the directory tree (starting from the directory containing `elm-tooling.json`) and errors out if no `node_modules` is found.

This is “unsound”. Consider this directory structure:

```
project/
	package.json
	node_modules/
	appA/
		elm.json
		elm-tooling.json
		src/
	appB/
		elm.json
		elm-tooling.json
		src/
```

What should `project/node_modules/.bin/elm` link to? `appA`’s Elm version or `appB`’s Elm version?

This PR fixes the `node_modules` locator. Now, `elm-tooling install` does the only correct thing – installs into `node_modules` in the same directory as `elm-tooling.json`. If `node_modules` doesn’t exist it is created.