### PR TITLE
Limit onProgress

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "26.0.20",
-    "@types/node": "14.14.21",
+    "@types/node": "14.14.22",
     "@types/rimraf": "3.0.0",
     "@typescript-eslint/eslint-plugin": "4.14.0",
     "@typescript-eslint/parser": "4.14.0",


### PR DESCRIPTION
I noticed that `onProgress` is called _much_ more often when falling back to the Node.js `https` module for downloads, than when using `curl` or `wget`.

This results in unnecessary terminal re-prints, which can be slow if done too often. It also looks really bad in CI, where lines usually don’t overwrite each other.

This PR:

- Calls `onProgress` at most 50 times per second for the `https` implementation.
- Never prints the same progress twice.
- Makes sure that `getExecutable` never calls its `onProgress` with the same number twice.