### PR TITLE
Make `npm ci` cache depend on package.json

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: internal-node_modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+          key: internal-node_modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package.json', 'package-lock.json') }}
 
       - name: npm ci
         if: steps.cache-node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: internal-node_modules-ubuntu-latest-15.x-${{ hashFiles('package-lock.json') }}
+          key: internal-node_modules-ubuntu-latest-15.x-${{ hashFiles('package.json', 'package-lock.json') }}
       - name: Internal npm ci
         if: steps.internal-cache-node_modules.outputs.cache-hit != 'true'
         run: npm ci
@@ -40,13 +40,13 @@ jobs:
         working-directory: .
       # IGNORE END
 
-      # Re-use node_modules between runs until package-lock.json changes.
+      # Re-use node_modules between runs until package.json or package-lock.json changes.
       - name: Cache node_modules
         id: cache-node_modules
         uses: actions/cache@v2
         with:
           path: example/node_modules
-          key: node_modules-${{ hashFiles('example/package-lock.json') }}
+          key: node_modules-${{ hashFiles('example/package.json', 'example/package-lock.json') }}
 
       # Re-use ~/.elm between runs until elm.json, elm-tooling.json or
       # review/elm.json changes. The Elm compiler saves downloaded Elm packages
@@ -60,6 +60,10 @@ jobs:
       # Install npm packages, unless we restored them from cache.
       # Since `npm ci` removes the node_modules folder before running it’s
       # important to skip this step if cache was restored.
+      # `npm ci` does two things:
+      # 1. Installs everything in package-lock.json.
+      # 2. Checks that package.json and package-lock.json are in sync.
+      # That’s why the cache depends on both package-lock.json and package.json.
       - name: npm ci
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: internal-node_modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+          key: internal-node_modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package.json', 'package-lock.json') }}
 
       - name: npm ci
         if: steps.cache-node_modules.outputs.cache-hit != 'true'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,7 +11,7 @@ See the [Example GitHub Actions workflow](https://github.com/elm-tooling/elm-too
 
 Basically, you need to:
 
-1. Install npm packages, with `NO_ELM_TOOLING_INSTALL` set. It’s nice to cache `node_modules` (based on your `package-lock.json`) for speed and reliability.
+1. Install npm packages, with `NO_ELM_TOOLING_INSTALL` set. It’s nice to cache `node_modules` (based on your `package.json` and `package-lock.json`) for speed and reliability.
 
    Setting the `NO_ELM_TOOLING_INSTALL` environment variable turns `elm-tooling install` into a no-op, in case you have a `"postinstall": "elm-tooling install"` script in your `package.json`. In CI it’s better to install npm packages and `elm-tooling.json` tools separately so you can cache `node_modules` and `~/.elm` separately.
 


### PR DESCRIPTION
`node_modules` only depends on package-lock.json, but running the
`npm ci` command itself also depends on package.json, because the
command verifies that package.json and package-lock.json are in sync.