### PR TITLE
Only reprint lines that change

### DIFF
--- a/scripts/Build.ts
+++ b/scripts/Build.ts
@@ -54,7 +54,7 @@ async function run(): Promise<void> {
   const bundle = await rollup({
     input: entry,
     external: builtinModules,
-    plugins: [typescript()],
+    plugins: [typescript({ module: "ESNext" })],
     onwarn: (warning) => {
       // Rollup warnings _do_ have a real `.toString()` method.
       // eslint-disable-next-line @typescript-eslint/no-base-to-string

--- a/scripts/TestAllDownloads.ts
+++ b/scripts/TestAllDownloads.ts
@@ -102,7 +102,12 @@ class CurorWriteStream extends stream.Writable implements WriteStream {
     const chunk = chunkBuffer.toString();
     const cursorMoveMatch = cursorMove.exec(chunk);
     // Only care about the first line and the progress, not the “link created” lines.
-    if (!this.hasWritten || chunk.includes("%") || cursorMoveMatch !== null) {
+    if (
+      !this.hasWritten ||
+      chunk.includes("%") ||
+      chunk.includes("ERR!") ||
+      cursorMoveMatch !== null
+    ) {
       readline.cursorTo(process.stdout, 0, this.y);
       process.stdout.write(chunk);
       readline.cursorTo(process.stdout, 0, calculateHeight(this.variants));

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,6 +3,5 @@
   "exclude": [],
   "compilerOptions": {
     "esModuleInterop": true,
-    "module": "CommonJS",
   }
 }

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,15 +1,15 @@
-import * as readline from "readline";
-
 import { Env, removeColor, WriteStream } from "./Helpers";
 
 export type Logger = {
   handleColor: (string: string) => string;
   log: (message: string) => void;
   error: (message: string) => void;
-  progress: (message: string) => void;
+  raw: {
+    NO_COLOR: boolean;
+    stdout: WriteStream;
+    stderr: WriteStream;
+  };
 };
-
-let previousProgress: number | undefined = undefined;
 
 export function makeLogger({
   env,
@@ -27,21 +27,15 @@ export function makeLogger({
   return {
     handleColor,
     log(message) {
-      previousProgress = undefined;
       stdout.write(`${handleColor(message)}\n`);
     },
     error(message) {
-      previousProgress = undefined;
       stderr.write(`${handleColor(message)}\n`);
     },
-    // istanbul ignore next
-    progress(passedMessage) {
-      const message = handleColor(passedMessage);
-      if (previousProgress !== undefined) {
-        readline.moveCursor(stdout, 0, -previousProgress);
-      }
-      previousProgress = message.split("\n").length;
-      stdout.write(`${message}\n`);
+    raw: {
+      NO_COLOR,
+      stdout,
+      stderr,
     },
   };
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../tsconfig.json",
   "exclude": [],
-  "compilerOptions": {
-    "module": "CommonJS",
-  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "forceConsistentCasingInFileNames": true,
     "importsNotUsedAsValues": "error",
     "isolatedModules": true,
-    "module": "ESNext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
- This is more efficient.
- By skipping the cursor movements for non-interactive outputs, this
  results in a good old log. Much nicer than logging one line for each
  downloaded tool every time _any_ of them changed (resulting in a lot
  of duplicate logged lines), which was the effect before.