### PR TITLE
Add elm-test-rs 2.0.0

### DIFF
--- a/src/KnownTools.ts
+++ b/src/KnownTools.ts
@@ -306,6 +306,29 @@ const knownTools = {
         type: "zip",
       },
     },
+    "2.0.0": {
+      linux: {
+        hash: "face27bfe2b886d3ba96ad77c3f52d312da0f6089163b6db1b1c76297518ec54",
+        url: "https://github.com/mpizenberg/elm-test-rs/releases/download/v2.0/elm-test-rs_linux.tar.gz",
+        fileSize: 3572480,
+        fileName: "elm-test-rs",
+        type: "tgz",
+      },
+      mac: {
+        hash: "b8a5c487d7fc60c3bbb40bf8616b4da726ce0ad867ea6295a07a4726f9fe105a",
+        url: "https://github.com/mpizenberg/elm-test-rs/releases/download/v2.0/elm-test-rs_macos.tar.gz",
+        fileSize: 2233532,
+        fileName: "elm-test-rs",
+        type: "tgz",
+      },
+      windows: {
+        hash: "5f4ae45981750ac17cd72a2711bacc21fee763840d3f18c2e73614666f510ee8",
+        url: "https://github.com/mpizenberg/elm-test-rs/releases/download/v2.0/elm-test-rs_windows.zip",
+        fileSize: 1897927,
+        fileName: "elm-test-rs.exe",
+        type: "zip",
+      },
+    },
   },
 } as const;
 

--- a/tests/Tools.test.ts
+++ b/tests/Tools.test.ts
@@ -111,6 +111,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -150,6 +151,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -195,6 +197,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -235,6 +238,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘▊⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -273,6 +277,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -323,6 +328,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -370,6 +376,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -422,6 +429,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -471,6 +479,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -511,6 +520,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -565,6 +575,7 @@ describe("tools", () => {
         ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
         ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+        ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
       ⧙Up⧘/⧙Down⧘ to move
       ⧙Space⧘ to toggle
@@ -663,6 +674,7 @@ describe("tools", () => {
           ⧙[⧘ ⧙]⧘ ⧙1.0.0⧘
           ⧙[⧘ ⧙]⧘ ⧙1.2.1⧘
           ⧙[⧘ ⧙]⧘ ⧙1.2.2⧘
+          ⧙[⧘ ⧙]⧘ ⧙2.0.0⧘
 
         ⧙Up⧘/⧙Down⧘ to move
         ⧙Space⧘ to toggle


### PR DESCRIPTION
I've started the process to add v2.0 of elm-test-rs in this PR. I hope I haven't mad a mistake in `Tools.test.ts` because this is basically what I see XD

![image](https://user-images.githubusercontent.com/2905865/144475143-d3ea6be7-fbd2-4eb3-a2ee-811420c17652.png)

So I've done some copy pasting.

Also I'm not sure how to change ` scripts/TestAllDownloads.expected.txt` that I see you changed in the previous release. Consider this PR as a starting point where I've already computed the hashes and sizes for the main config.