### PR TITLE
Update the Elm 0.19.1 ARM 64 binaries

### DIFF
--- a/src/KnownTools.ts
+++ b/src/KnownTools.ts
@@ -51,9 +51,9 @@ const knownTools = {
     },
     "0.19.1": {
       "darwin-arm64": {
-        hash: "c7d5322e39c938f5ba35c8a09c9f85387100d495bd0bd5011fc63c6c550b00d8",
-        url: "https://github.com/lydell/compiler/releases/download/0.19.1/binary-for-mac-arm-64-bit.gz",
-        fileSize: 14054287,
+        hash: "f33e70be12ee7db4209bf25ab96ffa8b79f4f29dfe5827542f45209a248626f1",
+        url: "https://github.com/lydell/compiler/releases/download/0.19.1/binary-for-mac-arm-64-bit-recommended.gz",
+        fileSize: 14091365,
         fileName: "elm",
         type: "gz",
       },
@@ -72,9 +72,9 @@ const knownTools = {
         type: "tgz",
       },
       "linux-arm64": {
-        hash: "a9123b40db040fc431ec8c2d275fa04ce260bc8d5eab5050ff5869477253605d",
-        url: "https://github.com/lydell/compiler/releases/download/0.19.1/binary-for-linux-arm-64-bit.gz",
-        fileSize: 4997442,
+        hash: "978ca677abc6ae27cface7468858adb782bd302730c7c564ff1b784a4a5b9235",
+        url: "https://github.com/lydell/compiler/releases/download/0.19.1/binary-for-linux-arm-64-bit-recommended.gz",
+        fileSize: 5208222,
         fileName: "elm",
         type: "gz",
       },


### PR DESCRIPTION
This switches to ARM 64 binaries compiled from the same commit as the official x86_64 binaries.

https://github.com/lydell/compiler/releases/tag/0.19.1

> Why are there _two_ macOS ARM 64-bit binaries, and _two_ Linux ARM 64-bit binaries?
> 
> - The two ending with `-recommended.gz` are compiled from the _same [commit](https://github.com/elm/compiler/commit/c9aefb6230f5e0bda03205ab0499f6e4af924495)_ as the official x86_64 binaries. They were created after the gotcha in the next point was discovered.
> - The other two were compiled from a later commit. They still work, but can result in surprises. There are some unreleased commits that result in ever so slightly different compiled JavaScript. Many build systems hash outputs for cache busting. If you run a binary compiled from a later commit locally but an official one on a build server, you might be confused why you get different hashes locally and on the build server for example. There’s also a risk that something compiles on your local computer, but not on the build server, or someone else’s computer (who doesn’t use ARM 64).
> - The two binaries compiled from a later commit cannot be removed without breaking [elm-tooling 1.11.0](https://github.com/elm-tooling/elm-tooling-cli/blob/main/CHANGELOG.md#version-1110-2023-01-08), so they’re still around.