### PR TITLE
Fix TypeScript .d.ts files

### DIFF
--- a/src/getExecutable.d.ts
+++ b/src/getExecutable.d.ts
@@ -1,7 +1,9 @@
-export default function getExecutable(options: {
+declare function getExecutable(options: {
   name: string;
   version: string;
   cwd?: string;
   env?: Record<string, string | undefined>;
   onProgress: (percentage: number) => void;
 }): Promise<string>;
+
+export = getExecutable;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,7 @@ type WriteStream = Writable & {
   isTTY: boolean;
 };
 
-export default function elmToolingCli(
+declare function elmToolingCli(
   args: Array<string>,
   options?: {
     cwd?: string;
@@ -19,3 +19,5 @@ export default function elmToolingCli(
     stderr?: WriteStream;
   }
 ): Promise<number>;
+
+export = elmToolingCli;


### PR DESCRIPTION
`export default` is apparently wrong for what we’re doing. `export =` is the correct one. Source: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/4706e9a84892be17888bb01a4d85c0bfed3230c2/docs/problems/FalseExportDefault.md

I’ve tested this with both `require` and `import` in both TS and JS files, with different `"module"` and `"moduleResolution"` settings, and it seems to work perfectly.

With this commit, it is now possible to do:

    const elmToolingCli = require("elm-tooling")

in an `@ts-check`ed JS file without errors – no errors at compile time, and no errors at runtime.