### PR TITLE
Update the Elm 0.19.1 macOS ARM 64 binary to the one compiled by Evan

### DIFF
--- a/src/KnownTools.ts
+++ b/src/KnownTools.ts
@@ -51,9 +51,9 @@ const knownTools = {
     },
     "0.19.1": {
       "darwin-arm64": {
-        hash: "f33e70be12ee7db4209bf25ab96ffa8b79f4f29dfe5827542f45209a248626f1",
-        url: "https://github.com/lydell/compiler/releases/download/0.19.1/binary-for-mac-arm-64-bit-recommended.gz",
-        fileSize: 14091365,
+        hash: "552c8300b55dafdf52073b095e7bc6afc1b2ea2a600fbc7654bca8a241e38689",
+        url: "https://github.com/lydell/compiler/releases/download/0.19.1/binary-for-mac-64-bit-ARM.gz",
+        fileSize: 11502530,
         fileName: "elm",
         type: "gz",
       },


### PR DESCRIPTION
As of this writing (2023-09-30), a macOS ARM binary is available in the [official Elm 0.19.1 release](https://github.com/elm/compiler/releases/tag/0.19.1) but not in the `elm` npm package. Since it’s not in the `elm` package, I got the feeling that the binary might be updated (but it seems to work flawlessly, so there shouldn’t be a need to do so), so I decided to copy it to https://github.com/lydell/compiler/releases/tag/0.19.1 and have `elm-tooling` download from there instead.

This new binary is built with a [newer GHC version](https://github.com/elm/compiler/commit/0421dfbe48e53d880a401e201890eac0b3de5f06), which solves a problem where you could get segfaults while installing Elm packages.